### PR TITLE
Remove 'weak' parameter from signal connect/disconnect

### DIFF
--- a/dauto/signals.py
+++ b/dauto/signals.py
@@ -60,14 +60,12 @@ class OutSignal:
         self.signal.disconnect(
             receiver=self.receiver,
             sender=self.sender,
-            dispatch_uid=self.dispatch_uid,
-            weak=False
+            dispatch_uid=self.dispatch_uid
         )
 
     def __exit__(self, type, value, traceback):
         self.signal.connect(
             receiver=self.receiver,
             sender=self.sender,
-            dispatch_uid=self.dispatch_uid,
-            weak=False
+            dispatch_uid=self.dispatch_uid
         )


### PR DESCRIPTION
The 'weak' parameter was used when connecting and disconnecting signals in dauto/signals.py. This parameter was deemed unnecessary and has been removed to simplify the code and avoid