### PR TITLE
Add field to handle nested resource serialization combined with HATEOAS principle

### DIFF
--- a/dauto/drf/restql/__init__.py
+++ b/dauto/drf/restql/__init__.py
@@ -1,0 +1,4 @@
+try:
+    import django_restql
+except ImportError as e:
+    raise ImportError("You must install dauto[django-restql] packages to use this package.")

--- a/dauto/drf/restql/fields.py
+++ b/dauto/drf/restql/fields.py
@@ -1,0 +1,151 @@
+# ??? warning
+#
+# We need to check if django_restql package is installed
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import Model
+from django_restql.mixins import DynamicFieldsMixin
+
+from dauto.drf.reverse import URLConfig, reverse
+
+from django_restql.fields import DynamicSerializerMethodField
+from django_restql.parser import Query
+from typing import Type
+from rest_framework.serializers import Serializer
+
+# Addressing Over-fetching and Under-fetching in RESTful APIs
+# RESTful APIs often suffer from over-fetching and under-fetching issues due to their rigid approach to handling response payloads.
+# These problems arise because REST endpoints return fixed sets of fields, which may include unnecessary data (over-fetching) or lack required data (under-fetching), forcing clients to make additional requests.
+
+# At its core, this is a design problem, as traditional REST APIs do not offer granular control over the response structure.
+# One effective way to tackle this issue in Django REST Framework (DRF) is by using the
+# [Django RESTQL](https://yezyilomo.github.io/django-restql/). This library transforms Django REST Framework (DRF) APIs into GraphQL-like APIs, enabling clients to specify the exact fields they need in a query-like format.
+
+# However, while this approach provides flexibility, it also encourages resource nesting, an opinionated practice that is often criticized from a design standpoint. Deeply nested structures can disrupt HATEOAS (Hypermedia as the Engine of Application State), a key principle in RESTful API design. HATEOAS advocates for hypertext-driven APIs, where resources are interconnected through hyperlinks rather than deeply nested objects.
+# First time you hear about this concept? We recommend you to read about it in:
+# - [REST APIs must be hypertext-driven » Untangled](https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven)
+# - [Richardson Maturity Model](https://martinfowler.com/articles/richardsonMaturityModel.html)
+
+# In essence, HATEOAS emphasizes that REST APIs should expose relationships between resources via hyperlinks rather than embedding them directly. Django REST Framework acknowledges this principle through the [HyperlinkedModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#hyperlinkedmodelserializer), which encourages hyperlinking resources rather than nesting them.
+# So, how can we leverage both mechanisms without compromising API design?
+
+# We need a solution that balances the flexibility of Django RESTQL while preserving HATEOAS principles. The HyperlinkedNestedSerializerMethodField is designed to achieve exactly that—allowing APIs to provide both hypermedia-driven links and selectively nested representations based on client queries.
+
+class HyperlinkedNestedSerializerMethodField(DynamicSerializerMethodField):
+    """
+    A specialized field that integrates HATEOAS (Hypermedia as the Engine of Application State)
+    with nested resource serialization in a single field.
+
+    This field allows:
+    - Dynamically generating hyperlinked URLs for related resources.
+    - Serializing nested resources when query arguments specify field inclusion or exclusion.
+
+    Behavior:
+    - If query parameters request specific nested fields, the related resource(s) will be serialized
+      using the provided `serializer_class`, respecting the parsed query structure.
+    - Otherwise, the field will return a hyperlink to the related resource, constructed using
+      a method defined on the parent serializer.
+
+    Parameters:
+        serializer_class (Type[Serializer]): The serializer class to use for nested resource serialization.
+        source (str, optional): The source attribute from which the field retrieves data. Defaults to `None`,
+            which assigns it to the field name.
+        many (bool, optional): Whether the field should handle multiple related instances. Defaults to `False`.
+        method_name (str): The name of the method on the parent serializer responsible for
+            providing the URL configuration. By default, is resolved with get_<field_name>
+
+    Raises:
+        ImproperlyConfigured: If the method specified in `method_name` does not return an instance of `URLConfig`.
+
+    Example:
+        class ExampleSerializer(serializers.Serializer):
+            related_resource = HyperlinkedNestedSerializerMethodField(
+                serializer_class=NestedResourceSerializer,
+                method_name="get_related_resource_url"
+            )
+
+            def get_related_resource_url(self, instance, parsed_query):
+                return URLConfig(
+                    view_name="related-resource-detail",
+                    path_params={"pk": instance.related.id},
+                )
+    """
+
+    # noinspection PyTypeChecker
+    def __init__(
+            self,
+            serializer_class: Type[Serializer],
+            source: str = None,
+            many: bool = False,
+            method_name: str = None,
+            **kwargs,
+    ):
+        super().__init__(method_name=method_name, **kwargs)
+
+        self.serializer_class = serializer_class
+        self.source = source or self.field_name
+        self.many = many
+
+    # noinspection PyTypeChecker,PyCallingNonCallable,PyUnresolvedReferences
+    def to_representation(self, value):
+        is_parsed_query_available = (
+                hasattr(self.parent, "restql_nested_parsed_queries")
+                and self.field_name in self.parent.restql_nested_parsed_queries
+        )
+
+        if is_parsed_query_available:
+            parsed_query = self.parent.restql_nested_parsed_queries[self.field_name]
+        else:
+            parsed_query = Query(
+                field_name=None,
+                included_fields=["*"],
+                excluded_fields=[],
+                aliases={},
+                arguments={},
+            )
+
+        has_fields = (
+                parsed_query.included_fields
+                and "*" not in parsed_query.included_fields
+                or parsed_query.excluded_fields
+                or parsed_query.aliases
+        )
+
+        if has_fields:
+            if issubclass(self.serializer_class, DynamicFieldsMixin):
+                return self.serializer_class(
+                    instance=value,
+                    context=self.context,
+                    parsed_query=parsed_query,
+                    many=self.many,
+                ).data
+            else:
+                return self.serializer_class(
+                    instance=value,
+                    context=self.context,
+                    many=self.many,
+                ).data
+
+
+        if not isinstance(value, Model):
+            value = self.parent.instance
+
+        url_config = self._get_url_config(value, parsed_query)
+        return self.reverse_url(url_config)
+
+    def reverse_url(self, url_config: URLConfig):
+        return reverse(
+            view_name=url_config.view_name,
+            kwargs=url_config.path_params,
+            query_kwargs=url_config.query_params,
+            request=self.parent.context.get("request"),
+        )
+
+    def _get_url_config(self, instance, parsed_query):
+        method = getattr(self.parent, self.method_name)
+        url_config = method(instance, parsed_query)
+        if not isinstance(url_config, URLConfig):
+            raise ImproperlyConfigured(
+                f"Method {self.method_name} in {self.parent.__class__.__name__} must return an {URLConfig.__name__} instance, its returning {url_config.__class__.__name__}"
+            )
+
+        return url_config

--- a/dauto/drf/reverse.py
+++ b/dauto/drf/reverse.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from urllib.parse import urlencode
 from rest_framework.reverse import reverse as drf_reverse
 
@@ -37,3 +38,13 @@ def reverse(
 #     query_kwargs={"country": "Cuba"},
 #     request=request,
 # )
+
+@dataclass(frozen=True)
+class URLConfig:
+    """
+    Simple dataclass for necessary url reverse configuration
+    """
+
+    view_name: str
+    path_params: dict[str, str] | None = None
+    query_params: dict[str, str] | None = None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,4 +31,5 @@ nav:
         dauto.drf.serializers: dauto/drf/serializers.md
         dauto.drf.throttling: dauto/drf/throttling.md
         dauto.drf.reverse: dauto/drf/reverse.md
+        dauto.drf.restql.fields: dauto/drf/restql/fields.md
         dauto.polymorphic:  dauto/polymorphic.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 rest=["djangorestframework"]
 polymorphic-rest=["django-rest-polymorphic"]
 polymorphic-model=["django-polymorphic"]
+django-restql=["django-restql"]
 dev=[
     "nox>=2025.2.9"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12.0"
 
 [[package]]
@@ -142,6 +143,7 @@ version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
+    { name = "django-restql" },
 ]
 
 [package.optional-dependencies]
@@ -157,6 +159,9 @@ all = [
 ]
 dev = [
     { name = "nox" },
+]
+django-restql = [
+    { name = "django-restql" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -181,6 +186,8 @@ requires-dist = [
     { name = "django-polymorphic", marker = "extra == 'polymorphic-model'" },
     { name = "django-rest-polymorphic", marker = "extra == 'all'" },
     { name = "django-rest-polymorphic", marker = "extra == 'polymorphic-rest'" },
+    { name = "django-restql", specifier = ">=0.16.2" },
+    { name = "django-restql", marker = "extra == 'django-restql'" },
     { name = "djangorestframework", marker = "extra == 'all'" },
     { name = "djangorestframework", marker = "extra == 'rest'" },
     { name = "mkdocs", marker = "extra == 'all'" },
@@ -194,6 +201,7 @@ requires-dist = [
     { name = "pylliterate", marker = "extra == 'all'" },
     { name = "pylliterate", marker = "extra == 'docs'" },
 ]
+provides-extras = ["rest", "polymorphic-rest", "polymorphic-model", "django-restql", "dev", "docs", "all"]
 
 [[package]]
 name = "dependency-groups"
@@ -255,6 +263,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/86/285f7da71ecd82ce6f1765ffb74425faf8244d8554cb6d00542286157701/django-rest-polymorphic-0.1.10.tar.gz", hash = "sha256:2960f58ed9a8bb0d42bc72c8ffaadfbd7f37d2573d42a1cd9a6460f3d572b519", size = 6464 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/90/e20bde06ea67111718ad8d03e21cccdfe37e24ccdff30ea22100a3004070/django_rest_polymorphic-0.1.10-py2.py3-none-any.whl", hash = "sha256:f3980e3e2af73357e7913f9b1410ef856866bcfcc46903b70fe9621118bb538c", size = 6027 },
+]
+
+[[package]]
+name = "django-restql"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "djangorestframework" },
+    { name = "pypeg2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/27/acbac4a9e0d8c94ff62e2d94d0242178214d0ec3da0e468f8bfc1c94b05c/django-restql-0.16.2.tar.gz", hash = "sha256:d32fd7e7ddf48eb69a98bc68f91aa50df26358a190be618781422d063f55e3c5", size = 28820 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/62/99f7a76b4e5f50ddf060d3b21040a21dc68d9ba05ae3e9c34652a86be24b/django_restql-0.16.2-py3-none-any.whl", hash = "sha256:cc914339e1f89b113bd11d34acbcc057655cd650663df596bcedb786bef063ba", size = 20246 },
 ]
 
 [[package]]
@@ -600,6 +622,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/7c/44/e6de2fdc880ad0ec7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/f5/b9e2a42aa8f9e34d52d66de87941ecd236570c7ed2e87775ed23bbe4e224/pymdown_extensions-10.14.3-py3-none-any.whl", hash = "sha256:05e0bee73d64b9c71a4ae17c72abc2f700e8bc8403755a00580b49a4e9f189e9", size = 264467 },
 ]
+
+[[package]]
+name = "pypeg2"
+version = "2.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/bd/10398e2c2d2070cc8a9c7153abfbd4ddb2895a2c52a32722ab8689e0cc7d/pyPEG2-2.15.2.tar.gz", hash = "sha256:2b2d4f80d8e1a9370b2a91f4a25f4abf7f69b85c8da84cd23ec36451958a1f6d", size = 40334 }
 
 [[package]]
 name = "python-dateutil"


### PR DESCRIPTION
# Addressing Over-fetching and Under-fetching in RESTful APIs
RESTful APIs often suffer from over-fetching and under-fetching issues due to their rigid approach to handling response payloads.
These problems arise because REST endpoints return fixed sets of fields, which may include unnecessary data (over-fetching) or lack required data (under-fetching), forcing clients to make additional requests.

At its core, this is a design problem, as traditional REST APIs do not offer granular control over the response structure.
One effective way to tackle this issue in Django REST Framework (DRF) is by using the [Django RESTQL](https://yezyilomo.github.io/django-restql/). This library transforms Django REST Framework (DRF) APIs into GraphQL-like APIs, enabling clients to specify the exact fields they need in a query-like format.

However, while this approach provides flexibility, it also encourages resource nesting, an opinionated practice that is often criticized from a design standpoint. Deeply nested structures can disrupt HATEOAS (Hypermedia as the Engine of Application State), a key principle in RESTful API design. HATEOAS advocates for hypertext-driven APIs, where resources are interconnected through hyperlinks rather than deeply nested objects.
First time you hear about this concept? We recommend you to read about it in:
 - [REST APIs must be hypertext-driven » Untangled](https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven)
 - [Richardson Maturity Model](https://martinfowler.com/articles/richardsonMaturityModel.html)

In essence, HATEOAS emphasizes that REST APIs should expose relationships between resources via hyperlinks rather than embedding them directly. Django REST Framework acknowledges this principle through the [HyperlinkedModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#hyperlinkedmodelserializer), which encourages hyperlinking resources rather than nesting them.
So, how can we leverage both mechanisms without compromising API design?

We need a solution that balances the flexibility of Django RESTQL while preserving HATEOAS principles. The HyperlinkedNestedSerializerMethodField is designed to achieve exactly that—allowing APIs to provide both hypermedia-driven links and selectively nested representations based on client queries.

```python
class HyperlinkedNestedSerializerMethodField(DynamicSerializerMethodField):
    """
    A specialized field that integrates HATEOAS (Hypermedia as the Engine of Application State)
    with nested resource serialization in a single field.

    This field allows:
    - Dynamically generating hyperlinked URLs for related resources.
    - Serializing nested resources when query arguments specify field inclusion or exclusion.

    Behavior:
    - If query parameters request specific nested fields, the related resource(s) will be serialized
      using the provided `serializer_class`, respecting the parsed query structure.
    - Otherwise, the field will return a hyperlink to the related resource, constructed using
      a method defined on the parent serializer.

    Parameters:
        serializer_class (Type[Serializer]): The serializer class to use for nested resource serialization.
        source (str, optional): The source attribute from which the field retrieves data. Defaults to `None`,
            which assigns it to the field name.
        many (bool, optional): Whether the field should handle multiple related instances. Defaults to `False`.
        method_name (str): The name of the method on the parent serializer responsible for
            providing the URL configuration. By default, is resolved with get_<field_name>

    Raises:
        ImproperlyConfigured: If the method specified in `method_name` does not return an instance of `URLConfig`.

    Example:
        class ExampleSerializer(serializers.Serializer):
            related_resource = HyperlinkedNestedSerializerMethodField(
                serializer_class=NestedResourceSerializer,
                method_name="get_related_resource_url"
            )

            def get_related_resource_url(self, instance, parsed_query):
                return URLConfig(
                    view_name="related-resource-detail",
                    path_params={"pk": instance.related.id},
                )
    """

    def __init__(
        self,
        serializer_class: Type[Serializer],
        source: str = None,
        many: bool = False,
        method_name: str = None,
        **kwargs,
    ):
        super().__init__(method_name=method_name, **kwargs)
        self._restql_utils = DjangoRestqlUtils()

        self.serializer_class = serializer_class
        self.source = source or self.field_name
        self.many = many

    # noinspection PyTypeChecker,PyUnresolvedReferences,PyCallingNonCallable
    def to_representation(self, value):
        is_parsed_query_available = (
            hasattr(self.parent, "restql_nested_parsed_queries")
            and self.field_name in self.parent.restql_nested_parsed_queries
        )

        if is_parsed_query_available:
            parsed_query = self.parent.restql_nested_parsed_queries[self.field_name]
        else:
            # Include all fields
            parsed_query = Query(
                field_name=None,
                included_fields=["*"],
                excluded_fields=[],
                aliases={},
                arguments={},
            )

        has_fields = (
            parsed_query.included_fields
            and "*" not in parsed_query.included_fields
            or parsed_query.excluded_fields
            or parsed_query.aliases
        )

        if has_fields:
            if issubclass(self.serializer_class, DynamicFieldsMixin):
                return self.serializer_class(
                    instance=value,
                    context=self.context,
                    parsed_query=parsed_query,
                    many=self.many,
                ).data
            else:
                return self.serializer_class(
                    instance=value,
                    context=self.context,
                    many=self.many,
                ).data

        if not isinstance(value, Model):
            value = self.parent.instance

        url_config = self._get_url_config(value, parsed_query)
        return self.reverse_url(url_config)

    def reverse_url(self, url_config: URLConfig):
        return reverse_querystring(
            view_name=url_config.view_name,
            kwargs=url_config.path_params,
            query_kwargs=url_config.query_params,
            request=self.parent.context.get("request"),
        )

    def _get_url_config(self, instance, parsed_query):
        method = getattr(self.parent, self.method_name)
        url_config = method(instance, parsed_query)
        if not isinstance(url_config, URLConfig):
            raise ImproperlyConfigured(
                f"Method {self.method_name} in {self.parent.__class__.__name__} must return an {URLConfig.__name__} instance, its returning {url_config.__class__.__name__}"
            )

        return url_config
```
